### PR TITLE
Updated link for Resources main tab

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -42,7 +42,7 @@ links:
       - title: International Awards
         url: /professional-excellence/international-awards/international-awards/
   - title: Resources
-    url: /permalink
+    url: /#
     sublinks:
       - title: OLive Staff Well Being
         url: https://olive.moe.edu.sg/


### PR DESCRIPTION
It was linking to /permalink page