### PR TITLE
Added alt tag for image on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,4 +61,5 @@ sections:
       button: Read more
       url: https://academyofsingaporeteachers.moe.edu.sg/professional-excellence/academy-awards/aa-stories/
       image: /images/Photo_1__Group.jpg
+      alt: Group photo at AA ceremony
 ---


### PR DESCRIPTION
Image of AA ceremony group photo for one of the items on homepage did not appear as its alt tag was missing.